### PR TITLE
security: pin CodeQL action dependencies to immutable SHAs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,17 +23,17 @@ jobs:
         language: [python, javascript]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@c7d0eebf0efb81753d773b54ee46f4278db8ab5d  # v3.25.12
         with:
           languages: ${{ matrix.language }}
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
+        uses: github/codeql-action/autobuild@c7d0eebf0efb81753d773b54ee46f4278db8ab5d  # v3.25.12
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@c7d0eebf0efb81753d773b54ee46f4278db8ab5d  # v3.25.12
         with:
           category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
Pinned all GitHub Actions to specific commit SHAs to prevent supply chain attacks from mutable tags. This addresses Pinned-Dependencies security alert.

## Description

Please include a summary of the changes and which issue is fixed. Include relevant motivation and context.

Fixes # (issue)

## Type of Change

Please delete options that are not relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] CI/CD or tooling changes

## Changes Made

Provide a clear list of changes:

- Change 1
- Change 2
- Change 3

## Testing

Describe the tests you ran to verify your changes:

- [ ] Test A
- [ ] Test B
- [ ] All existing tests pass

**Test Configuration**:
- Node.js version:
- OS:
- Docker version (if applicable):

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

Add screenshots to help explain your changes.

## Additional Notes

Any additional information or context about the pull request.
