### PR TITLE
[FIX] devskim.yml: remove duplicate 'uses:' keys (root cause of 0-job failure)

### DIFF
--- a/.github/workflows/devskim.yml
+++ b/.github/workflows/devskim.yml
@@ -19,7 +19,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
-        uses: actions/checkout@v6
 
       - name: Run DevSkim scanner
         uses: microsoft/DevSkim-Action@bff32d3fc4b03f2e10a3c39db0909a71b2a29f06  # v1.0
@@ -28,6 +27,5 @@ jobs:
 
       - name: Upload DevSkim SARIF file
         uses: github/codeql-action/upload-sarif@c7d0eebf0efb81753d773b54ee46f4278db8ab5d  # v3.25.12
-        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: devskim-results.sarif


### PR DESCRIPTION
## 🔴 Critical CI Blocker Fix

### Root Cause
devskim.yml was silently failing with **0-second duration** (no jobs executed) due to **duplicate `uses:` keys** on two workflow steps:

**Before (BROKEN):**
```yaml
- name: Checkout repository
  uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
  uses: actions/checkout@v6  # ← DUPLICATE — BREAKS WORKFLOW

- name: Upload DevSkim SARIF file
  uses: github/codeql-action/upload-sarif@c7d0eebf0efb81753d773b54ee46f4278db8ab5d  # v3.25.12
  uses: github/codeql-action/upload-sarif@v4  # ← DUPLICATE — BREAKS WORKFLOW
```

GitHub YAML parser encounters the duplicate key and silently **skips the entire workflow**. This is why all DevSkim jobs show "failed" with 0-second duration—they never ran at all.

### Fix
Remove non-SHA `uses:` lines, keeping only the pinned SHA versions for immutability:

**After (FIXED):**
```yaml
- name: Checkout repository
  uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2

- name: Upload DevSkim SARIF file
  uses: github/codeql-action/upload-sarif@c7d0eebf0efb81753d773b54ee46f4278db8ab5d  # v3.25.12
  with:
    sarif_file: devskim-results.sarif
```

### Expected Behavior (Post-Merge)
- ✅ DevSkim workflow triggers on `main` pushes/PRs and weekly Sunday 01:30 UTC cron
- ✅ Checkout completes successfully
- ✅ DevSkim scanner runs and produces SARIF output
- ✅ SARIF results upload to GitHub Security tab
- ✅ Job completes in <2 minutes (not 0 seconds)

### Verification
Run workflow manually after merge to confirm:
```bash
gh workflow run devskim.yml --ref fix/devskim-duplicate-uses
```

### Related Issues
Fixes Phase 0 CI stabilization (part of CIVWATCH standalone .exe roadmap)

**Labels:** `bug`, `ci-cd`, `high-priority`