### PR TITLE
feat: Feed Ingestion Layer — public DOT cameras, YouTube live embeds, FeedMap component

### DIFF
--- a/backend/src/feeds/ingestor.js
+++ b/backend/src/feeds/ingestor.js
@@ -1,0 +1,87 @@
+/**
+ * CIVWATCH Feed Ingestor
+ * Polls all enabled sources in source_registry.json and emits normalized FeedEvents.
+ * Runs as a standalone service or imported into the main backend.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const https = require('https');
+const http = require('http');
+const { normalizeEvent } = require('./normalizer');
+
+const REGISTRY_PATH = path.join(__dirname, 'source_registry.json');
+const registry = JSON.parse(fs.readFileSync(REGISTRY_PATH, 'utf8'));
+
+const activeTimers = {};
+const feedCache = {}; // in-memory: sourceId -> latest FeedEvent[]
+
+function fetchJSON(url) {
+  return new Promise((resolve, reject) => {
+    const client = url.startsWith('https') ? https : http;
+    client.get(url, { headers: { 'User-Agent': 'CIVWATCH/1.0 (civic transparency)' } }, (res) => {
+      let data = '';
+      res.on('data', chunk => data += chunk);
+      res.on('end', () => {
+        try { resolve(JSON.parse(data)); }
+        catch (e) { reject(new Error(`Parse error for ${url}: ${e.message}`)); }
+      });
+    }).on('error', reject);
+  });
+}
+
+async function pollSource(source) {
+  if (!source.enabled) return;
+  if (source.type === 'yt_live' || source.type === 'webcam_embed') {
+    // Static embed sources — just normalize directly, no HTTP fetch needed
+    const event = normalizeEvent(source, null);
+    feedCache[source.id] = [event];
+    return;
+  }
+  try {
+    const raw = await fetchJSON(source.url);
+    const events = Array.isArray(raw)
+      ? raw.map(item => normalizeEvent(source, item))
+      : [normalizeEvent(source, raw)];
+    feedCache[source.id] = events;
+    console.log(`[CIVWATCH FIL] ${source.id}: ${events.length} events cached`);
+  } catch (err) {
+    console.error(`[CIVWATCH FIL] ${source.id} error: ${err.message}`);
+  }
+}
+
+function startIngestor() {
+  console.log(`[CIVWATCH FIL] Starting with ${registry.length} sources`);
+  for (const source of registry) {
+    if (!source.enabled) continue;
+    // Initial poll immediately
+    pollSource(source);
+    // Then poll on interval (skip for 0 rate_limit static embeds)
+    if (source.rate_limit_ms > 0) {
+      activeTimers[source.id] = setInterval(() => pollSource(source), source.rate_limit_ms);
+    }
+  }
+}
+
+function stopIngestor() {
+  for (const id of Object.keys(activeTimers)) {
+    clearInterval(activeTimers[id]);
+    delete activeTimers[id];
+  }
+}
+
+function getAllFeedEvents() {
+  return Object.values(feedCache).flat();
+}
+
+function getFeedEventsByTag(tag) {
+  return getAllFeedEvents().filter(e => e.tags && e.tags.includes(tag));
+}
+
+module.exports = { startIngestor, stopIngestor, getAllFeedEvents, getFeedEventsByTag, feedCache };
+
+// Run standalone if called directly
+if (require.main === module) {
+  startIngestor();
+  console.log('[CIVWATCH FIL] Ingestor running. Ctrl+C to stop.');
+}

--- a/backend/src/feeds/normalizer.js
+++ b/backend/src/feeds/normalizer.js
@@ -1,0 +1,99 @@
+/**
+ * CIVWATCH Feed Normalizer
+ * Converts raw API responses from heterogeneous sources into a canonical FeedEvent.
+ *
+ * FeedEvent schema:
+ * {
+ *   source_id: string,
+ *   source_type: 'dot_camera' | 'yt_live' | 'webcam_embed',
+ *   label: string,
+ *   embed_url: string | null,
+ *   snapshot_url: string | null,
+ *   timestamp_utc: ISO8601 string,
+ *   geo: { lat: number, lng: number } | null,
+ *   tags: string[],
+ *   raw_id: string | null
+ * }
+ */
+
+function normalizeEvent(source, raw) {
+  const base = {
+    source_id: source.id,
+    source_type: source.type,
+    label: source.label,
+    embed_url: null,
+    snapshot_url: null,
+    timestamp_utc: new Date().toISOString(),
+    geo: source.geo || null,
+    tags: source.tags || [],
+    raw_id: null
+  };
+
+  switch (source.type) {
+
+    case 'yt_live':
+      return { ...base, embed_url: source.url, snapshot_url: null };
+
+    case 'webcam_embed':
+      return { ...base, embed_url: source.url, snapshot_url: source.snapshot_url || null };
+
+    case 'dot_camera': {
+      if (!raw) return base;
+
+      // Iowa / Minnesota / NY 511 pattern
+      if (raw.Latitude !== undefined && raw.Longitude !== undefined) {
+        return {
+          ...base,
+          label: raw.Name || raw.Description || source.label,
+          embed_url: raw.VideoUrl || raw.Url || null,
+          snapshot_url: raw.SnapshotUrl || raw.ImageUrl || null,
+          geo: { lat: parseFloat(raw.Latitude), lng: parseFloat(raw.Longitude) },
+          raw_id: raw.ID || raw.CameraID || null
+        };
+      }
+
+      // WSDOT pattern
+      if (raw.CameraLocation) {
+        return {
+          ...base,
+          label: raw.Title || raw.Description || source.label,
+          embed_url: null,
+          snapshot_url: raw.ImageUrl || null,
+          geo: {
+            lat: parseFloat(raw.CameraLocation.Latitude),
+            lng: parseFloat(raw.CameraLocation.Longitude)
+          },
+          raw_id: raw.CameraID || null
+        };
+      }
+
+      // Colorado COTrip pattern
+      if (raw.deviceLocation) {
+        return {
+          ...base,
+          label: raw.staticMessage || source.label,
+          snapshot_url: raw.imageUrl || null,
+          geo: {
+            lat: parseFloat(raw.deviceLocation.latitude),
+            lng: parseFloat(raw.deviceLocation.longitude)
+          },
+          raw_id: raw.deviceId || null
+        };
+      }
+
+      // Generic fallback
+      return {
+        ...base,
+        label: raw.name || raw.label || raw.title || source.label,
+        snapshot_url: raw.imageUrl || raw.snapshot || raw.url || null,
+        geo: raw.lat && raw.lng ? { lat: parseFloat(raw.lat), lng: parseFloat(raw.lng) } : base.geo,
+        raw_id: raw.id || raw.ID || null
+      };
+    }
+
+    default:
+      return base;
+  }
+}
+
+module.exports = { normalizeEvent };

--- a/backend/src/feeds/routes.js
+++ b/backend/src/feeds/routes.js
@@ -1,0 +1,34 @@
+/**
+ * CIVWATCH Feed Routes
+ * Exposes feed data to the frontend via REST.
+ * Mount this in backend/src/index.js: app.use('/api/feeds', require('./feeds/routes'));
+ */
+
+const express = require('express');
+const router = express.Router();
+const { getAllFeedEvents, getFeedEventsByTag, feedCache } = require('./ingestor');
+
+// GET /api/feeds — all normalized feed events
+router.get('/', (req, res) => {
+  res.json(getAllFeedEvents());
+});
+
+// GET /api/feeds/tag/:tag — filter by tag
+router.get('/tag/:tag', (req, res) => {
+  res.json(getFeedEventsByTag(req.params.tag));
+});
+
+// GET /api/feeds/source/:id — single source latest events
+router.get('/source/:id', (req, res) => {
+  const events = feedCache[req.params.id];
+  if (!events) return res.status(404).json({ error: 'source not found or not yet polled' });
+  res.json(events);
+});
+
+// GET /api/feeds/geo — all events that have a geo coordinate (for map layer)
+router.get('/geo', (req, res) => {
+  const events = getAllFeedEvents().filter(e => e.geo && e.geo.lat && e.geo.lng);
+  res.json(events);
+});
+
+module.exports = router;

--- a/backend/src/feeds/source_registry.json
+++ b/backend/src/feeds/source_registry.json
@@ -1,0 +1,112 @@
+[
+  {
+    "id": "iowa_dot_511",
+    "type": "dot_camera",
+    "label": "Iowa DOT 511 Traffic Cameras",
+    "url": "https://api.511iowa.org/api/cameras",
+    "embed_base": null,
+    "geo_field": "location",
+    "rate_limit_ms": 30000,
+    "enabled": true,
+    "tags": ["traffic", "iowa", "dot", "public_infrastructure"]
+  },
+  {
+    "id": "ny_511_cameras",
+    "type": "dot_camera",
+    "label": "New York 511 Traffic Cameras",
+    "url": "https://511ny.org/api/getcameras?format=json",
+    "embed_base": null,
+    "geo_field": "Latitude,Longitude",
+    "rate_limit_ms": 60000,
+    "enabled": true,
+    "tags": ["traffic", "new_york", "dot", "public_infrastructure"]
+  },
+  {
+    "id": "wsdot_cameras",
+    "type": "dot_camera",
+    "label": "Washington State DOT Traffic Cameras",
+    "url": "https://www.wsdot.wa.gov/Traffic/api/Cameras/CameraAPI.ashx?AccessCode=public&Action=GetCameras",
+    "embed_base": null,
+    "geo_field": "CameraLocation",
+    "rate_limit_ms": 60000,
+    "enabled": true,
+    "tags": ["traffic", "washington", "dot", "public_infrastructure"]
+  },
+  {
+    "id": "mn_dot_cameras",
+    "type": "dot_camera",
+    "label": "Minnesota DOT Traffic Cameras",
+    "url": "https://511mn.org/api/getcameras?format=json",
+    "embed_base": null,
+    "geo_field": "Latitude,Longitude",
+    "rate_limit_ms": 60000,
+    "enabled": true,
+    "tags": ["traffic", "minnesota", "dot", "public_infrastructure"]
+  },
+  {
+    "id": "co_cotrip_cameras",
+    "type": "dot_camera",
+    "label": "Colorado CDOT COTrip Cameras",
+    "url": "https://cotrip.org/device/getDevices.do?type=Camera",
+    "embed_base": null,
+    "geo_field": "deviceLocation",
+    "rate_limit_ms": 60000,
+    "enabled": true,
+    "tags": ["traffic", "colorado", "dot", "public_infrastructure"]
+  },
+  {
+    "id": "earthcam_times_square",
+    "type": "yt_live",
+    "label": "EarthCam Times Square Live",
+    "url": "https://www.youtube.com/embed/KKMhTBEWuq0?autoplay=1&mute=1",
+    "embed_base": "https://www.youtube.com/embed/",
+    "geo": { "lat": 40.7580, "lng": -73.9855 },
+    "rate_limit_ms": 0,
+    "enabled": true,
+    "tags": ["live", "public_space", "new_york", "youtube"]
+  },
+  {
+    "id": "earthcam_chicago_riverwalk",
+    "type": "yt_live",
+    "label": "EarthCam Chicago Riverwalk Live",
+    "url": "https://www.youtube.com/embed/5eTCZ9LXZMQ?autoplay=1&mute=1",
+    "embed_base": "https://www.youtube.com/embed/",
+    "geo": { "lat": 41.8868, "lng": -87.6270 },
+    "rate_limit_ms": 0,
+    "enabled": true,
+    "tags": ["live", "public_space", "chicago", "youtube"]
+  },
+  {
+    "id": "earthcam_dc_mall",
+    "type": "yt_live",
+    "label": "National Mall Washington DC Live",
+    "url": "https://www.youtube.com/embed/GHAqBSvepH8?autoplay=1&mute=1",
+    "embed_base": "https://www.youtube.com/embed/",
+    "geo": { "lat": 38.8895, "lng": -77.0353 },
+    "rate_limit_ms": 0,
+    "enabled": true,
+    "tags": ["live", "public_space", "washington_dc", "youtube"]
+  },
+  {
+    "id": "webcamtaxi_niagara",
+    "type": "webcam_embed",
+    "label": "Niagara Falls Public Webcam",
+    "url": "https://www.webcamtaxi.com/en/canada/ontario/niagara-falls.html",
+    "snapshot_url": "https://icons.wxug.com/webcams/camshots/1/niagarafalls.jpg",
+    "geo": { "lat": 43.0962, "lng": -79.0377 },
+    "rate_limit_ms": 30000,
+    "enabled": true,
+    "tags": ["public_space", "nature", "canada", "webcam"]
+  },
+  {
+    "id": "dot_open_511_feed",
+    "type": "dot_camera",
+    "label": "511 National Open Data Feed",
+    "url": "https://511.org/open-data/cameras",
+    "embed_base": null,
+    "geo_field": "location",
+    "rate_limit_ms": 120000,
+    "enabled": true,
+    "tags": ["traffic", "national", "511", "public_infrastructure"]
+  }
+]

--- a/frontend/src/components/FeedMap.jsx
+++ b/frontend/src/components/FeedMap.jsx
@@ -1,0 +1,108 @@
+/**
+ * CIVWATCH FeedMap Component
+ * Renders all geolocated public feed events on a Leaflet map.
+ * Click any marker to open the embed or snapshot inline.
+ *
+ * Dependencies: react-leaflet, leaflet
+ * Install: npm install react-leaflet leaflet
+ */
+
+import React, { useEffect, useState } from 'react';
+import { MapContainer, TileLayer, Marker, Popup } from 'react-leaflet';
+import 'leaflet/dist/leaflet.css';
+import L from 'leaflet';
+
+// Fix Leaflet default icon path issue in bundlers
+delete L.Icon.Default.prototype._getIconUrl;
+L.Icon.Default.mergeOptions({
+  iconRetinaUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/images/marker-icon-2x.png',
+  iconUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/images/marker-icon.png',
+  shadowUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/images/marker-shadow.png',
+});
+
+export default function FeedMap() {
+  const [events, setEvents] = useState([]);
+  const [selected, setSelected] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetch('/api/feeds/geo')
+      .then(r => r.json())
+      .then(data => { setEvents(data); setLoading(false); })
+      .catch(() => setLoading(false));
+  }, []);
+
+  return (
+    <div style={{ width: '100%', height: '100vh', display: 'flex', flexDirection: 'column' }}>
+      <div style={{ padding: '8px 16px', background: '#0d1117', color: '#58a6ff', fontFamily: 'monospace', fontSize: 13 }}>
+        CIVWATCH · Public Feed Map · {events.length} sources live
+      </div>
+
+      <MapContainer
+        center={[39.5, -98.35]}
+        zoom={4}
+        style={{ flex: 1 }}
+        preferCanvas
+      >
+        <TileLayer
+          attribution='&copy; <a href="https://www.openstreetmap.org">OpenStreetMap</a>'
+          url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+        />
+
+        {events.map((event, i) => (
+          <Marker
+            key={`${event.source_id}-${event.raw_id || i}`}
+            position={[event.geo.lat, event.geo.lng]}
+            eventHandlers={{ click: () => setSelected(event) }}
+          >
+            <Popup>
+              <div style={{ minWidth: 220 }}>
+                <strong>{event.label}</strong>
+                <div style={{ fontSize: 11, color: '#666', marginBottom: 6 }}>
+                  {event.tags.join(' · ')}
+                </div>
+
+                {event.embed_url && event.source_type === 'yt_live' && (
+                  <iframe
+                    width="220"
+                    height="130"
+                    src={event.embed_url}
+                    frameBorder="0"
+                    allow="autoplay; encrypted-media"
+                    allowFullScreen
+                    title={event.label}
+                  />
+                )}
+
+                {event.snapshot_url && !event.embed_url && (
+                  <img
+                    src={event.snapshot_url}
+                    alt={event.label}
+                    style={{ width: '100%', borderRadius: 4 }}
+                  />
+                )}
+
+                {!event.embed_url && !event.snapshot_url && (
+                  <div style={{ fontSize: 11, color: '#999' }}>No embed available</div>
+                )}
+
+                <div style={{ fontSize: 10, color: '#aaa', marginTop: 4 }}>
+                  {event.source_type} · {new Date(event.timestamp_utc).toLocaleTimeString()}
+                </div>
+              </div>
+            </Popup>
+          </Marker>
+        ))}
+      </MapContainer>
+
+      {loading && (
+        <div style={{
+          position: 'absolute', top: '50%', left: '50%', transform: 'translate(-50%,-50%)',
+          background: '#0d1117', color: '#58a6ff', padding: 16, borderRadius: 8, fontFamily: 'monospace'
+        }}>
+          Loading feeds...
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## What this adds

A complete Feed Ingestion Layer (FIL) that pulls public camera and live stream data into CIVWATCH and renders it on a map.

### Files added

| File | Purpose |
|------|--------|
| `backend/src/feeds/source_registry.json` | 10 real public sources: Iowa DOT, NY 511, WSDOT, MN DOT, CO COTrip, EarthCam embeds, National Mall DC live, Niagara webcam, 511 national feed |
| `backend/src/feeds/ingestor.js` | Polling service — reads registry, fetches all enabled sources on their rate schedules, caches normalized events in memory |
| `backend/src/feeds/normalizer.js` | Converts raw API responses from all source types into a canonical `FeedEvent` schema |
| `backend/src/feeds/routes.js` | Express REST routes: `GET /api/feeds`, `/api/feeds/geo`, `/api/feeds/tag/:tag`, `/api/feeds/source/:id` |
| `frontend/src/components/FeedMap.jsx` | Leaflet map — plots all geolocated feed events, click any marker for live embed or snapshot |

### To wire in

In `backend/src/index.js`, add:
```js
const { startIngestor } = require('./feeds/ingestor');
app.use('/api/feeds', require('./feeds/routes'));
startIngestor();
```

In your frontend router, add:
```jsx
import FeedMap from './components/FeedMap';
// <Route path="/map" element={<FeedMap />} />
```

### Source types covered
- Public DOT traffic camera REST APIs (Iowa, NY, WA, MN, CO)
- YouTube live embeds (EarthCam public channels)
- Open webcam directories (WebcamTaxi)
- 511 national open data feed

All sources are public infrastructure. No auth required for initial set. Rate limits are per-source in the registry.